### PR TITLE
Карточная игра 2. Внедрить поддержку способностей карт на уровень ядра  приложения

### DIFF
--- a/vue/src/components/App.vue
+++ b/vue/src/components/App.vue
@@ -26,7 +26,7 @@ export default {
       const engine = this.getGameEngine;
       const { left, right, top, bottom } = this.$refs.playerDesk.$refs.lines.getBoundingClientRect();
       const card = engine.player.cards[cardIndex];
-      const lineId = card.type === CardType.MELEE ? 'player-melee-cards' : 'player-range-cards';
+      const lineId = card.getType() === CardType.MELEE ? 'player-melee-cards' : 'player-range-cards';
       const line = document.querySelector(`#${lineId} > .desk-line__cards`);
       const cardsNodes = line.childNodes;
 

--- a/vue/src/components/game/DeskLine.vue
+++ b/vue/src/components/game/DeskLine.vue
@@ -35,9 +35,9 @@
           v-for="(card, index) in cards"
           :index="index"
           :key="index"
-          :score="card.score"
-          :type="card.type"
-          :image-uri="card.image"
+          :score="card.getScore()"
+          :type="card.getType()"
+          :image-uri="card.getImage()"
           :is-opponent="isOpponent"
       />
     </div>
@@ -69,7 +69,7 @@ export default {
       },
       validator(value) {
         return Array.isArray(value)
-          && value.every(item => typeof item.score === "number");
+          && value.every(item => typeof item.getScore() === "number");
       },
     },
   },

--- a/vue/src/components/game/PlayerHand.vue
+++ b/vue/src/components/game/PlayerHand.vue
@@ -9,9 +9,9 @@
       >
         <GameCard
           :key="index"
-          :type="card.type"
-          :score="card.score"
-          :image-uri="card.image"
+          :type="card.getType()"
+          :score="card.getScore()"
+          :image-uri="card.getImage()"
           :face-down="opponent"
           :enlarged="!opponent"
           :is-opponent="opponent"

--- a/vue/src/engine/ability.js
+++ b/vue/src/engine/ability.js
@@ -1,0 +1,55 @@
+export class AbilityContext {
+  engine = null;
+
+  constructor(engine) {
+    this.engine = engine;
+  }
+
+  getEngine() {
+    return this.engine;
+  }
+}
+
+export class PlayCardAbilityContext extends AbilityContext {
+  cardIndex = null;
+  position = null;
+
+  constructor(engine, cardIndex, position) {
+    super(engine);
+
+    this.cardIndex = cardIndex;
+    this.position = position;
+  }
+
+  getCardIndex() {
+    return this.cardIndex;
+  }
+
+  getPosition() {
+    return this.position;
+  }
+}
+
+export class PlayCardAbilityResponse {
+  dropPlayerCard = false;
+
+  constructor(dropPlayerCard = false) {
+    this.dropPlayerCard = dropPlayerCard;
+  }
+
+  getDropPlayerCard() {
+    return this.dropPlayerCard;
+  }
+}
+
+export class AbilityCollection {
+  playCardAbility = null;
+
+  constructor(playCardAbility = null) {
+    this.playCardAbility = playCardAbility;
+  }
+
+  onPlayCardAbility(context) {
+    return this.playCardAbility?.(context);
+  }
+}

--- a/vue/src/engine/board.js
+++ b/vue/src/engine/board.js
@@ -80,7 +80,7 @@ export class Board {
         break;
 
       default:
-        console.error('Invalid cardType: ', card);
+        throw new Error('Invalid cardType');
     }
   }
 

--- a/vue/src/engine/board.js
+++ b/vue/src/engine/board.js
@@ -6,11 +6,11 @@ export class Board {
   secondLineCards = [];
 
   getFirstLineScore() {
-    return this.firstLineCards.reduce((score, card) => score + card.score, 0);
+    return this.firstLineCards.reduce((score, card) => score + card.getScore(), 0);
   }
 
   getSecondLineScore() {
-    return this.secondLineCards.reduce((score, card) => score + card.score, 0);
+    return this.secondLineCards.reduce((score, card) => score + card.getScore(), 0);
   }
 
   getTotalScore() {
@@ -70,7 +70,7 @@ export class Board {
   }
 
   addCard(card, position) {
-    switch (card.type) {
+    switch (card.getType()) {
       case CardType.MELEE:
         this.addFirstLineCard(card, position);
         break;

--- a/vue/src/engine/card.js
+++ b/vue/src/engine/card.js
@@ -1,13 +1,19 @@
+import { AbilityCollection } from "./ability";
+
+const EmptyAbilityCollection = new AbilityCollection();
+
 export class Card {
   type = null;
   score = null;
   image = null;
+  abilities = null;
   new = false;
 
-  constructor(type, score, image) {
+  constructor(type, score, image, abilities = EmptyAbilityCollection) {
     this.type = type;
     this.score = score;
     this.image = image;
+    this.abilities = abilities;
   }
 
   getType() {
@@ -28,5 +34,9 @@ export class Card {
 
   setNew(value) {
     this.new = value;
+  }
+
+  getAbilities() {
+    return this.abilities;
   }
 }

--- a/vue/src/engine/card.js
+++ b/vue/src/engine/card.js
@@ -1,0 +1,32 @@
+export class Card {
+  type = null;
+  score = null;
+  image = null;
+  new = false;
+
+  constructor(type, score, image) {
+    this.type = type;
+    this.score = score;
+    this.image = image;
+  }
+
+  getType() {
+    return this.type;
+  }
+
+  getScore() {
+    return this.score;
+  }
+
+  getImage() {
+    return this.image;
+  }
+
+  getNew() {
+    return this.new;
+  }
+
+  setNew(value) {
+    this.new = value;
+  }
+}

--- a/vue/src/engine/constants.js
+++ b/vue/src/engine/constants.js
@@ -1,4 +1,5 @@
 import { Card } from "@/engine/card";
+import { AbilityCollection, PlayCardAbilityResponse } from "./ability";
 
 export const MAX_CARDS_PER_LINE = 7;
 
@@ -29,7 +30,22 @@ export const INIT_DECK = [
   new Card(CardType.RANGE, 8, 'yennefer.jpeg'),
   new Card(CardType.MELEE, 2, 'dandelion.jpeg'),
   new Card(CardType.MELEE, 10, 'zoltan-chiva.png'),
-  new Card(CardType.MELEE, 9, 'ciri.jpeg'),
+  new Card(CardType.MELEE, 9, 'ciri.jpeg', new AbilityCollection(
+    (context) => {
+      const engine = context.getEngine();
+      const oppositeLine = (engine.currentTurn !== TurnStates.PLAYER
+        ? engine.player
+        : engine.opponent).board.firstLineCards;
+
+      console.log(oppositeLine);
+
+      // Find geralt-of-rivia in the opposite line
+      const isFound = oppositeLine.findIndex(card => card.image === 'geralt-of-rivia.jpeg') !== -1;
+      console.log(isFound);
+
+      return new PlayCardAbilityResponse(isFound);
+    }
+  )),
   new Card(CardType.MELEE, 6, 'roche.png'),
   new Card(CardType.MELEE, 10, 'emgir-var-emreis.jpeg'),
   new Card(CardType.RANGE, 7, 'gyunter.jpeg'),

--- a/vue/src/engine/constants.js
+++ b/vue/src/engine/constants.js
@@ -1,3 +1,5 @@
+import { Card } from "@/engine/card";
+
 export const MAX_CARDS_PER_LINE = 7;
 
 export const GamePhases = {
@@ -22,82 +24,22 @@ export const CardType = {
 };
 
 export const INIT_DECK = [
-  {
-    type: CardType.MELEE,
-    score: 10,
-    image: 'geralt-of-rivia.jpeg',
-  },
-  {
-    type: CardType.RANGE,
-    score: 7,
-    image: 'triss-merigold.jpeg',
-  },
-  {
-    type: CardType.RANGE,
-    score: 8,
-    image: 'yennefer.jpeg',
-  },
-  {
-    type: CardType.MELEE,
-    score: 2,
-    image: 'dandelion.jpeg',
-  },
-  {
-    type: CardType.MELEE,
-    score: 10,
-    image: 'zoltan-chiva.png',
-  },
-  {
-    type: CardType.MELEE,
-    score: 9,
-    image: 'ciri.jpeg',
-  },
-  {
-    type: CardType.MELEE,
-    score: 6,
-    image: 'roche.png',
-  },
-  {
-    type: CardType.MELEE,
-    score: 10,
-    image: 'emgir-var-emreis.jpeg',
-  },
-  {
-    type: CardType.RANGE,
-    score: 7,
-    image: 'gyunter.jpeg',
-  },
-  {
-    type: CardType.RANGE,
-    score: 5,
-    image: 'iorvet.jpeg',
-  },
-  {
-    type: CardType.MELEE,
-    score: 3,
-    image: 'kerak.jpeg',
-  },
-  {
-    type: CardType.MELEE,
-    score: 6,
-    image: 'lamberd.jpeg',
-  },
-  {
-    type: CardType.MELEE,
-    score: 4,
-    image: 'leo-bonart.jpeg',
-  },
-  {
-    type: CardType.MELEE,
-    score: 9,
-    image: 'vesemir.jpeg',
-  },
-  {
-    type: CardType.MELEE,
-    score: 7,
-    image: 'yapen-zigrin.jpeg',
-  },
-].map(card => ({...card, new: false}));
+  new Card(CardType.MELEE, 10, 'geralt-of-rivia.jpeg'),
+  new Card(CardType.RANGE, 7, 'triss-merigold.jpeg'),
+  new Card(CardType.RANGE, 8, 'yennefer.jpeg'),
+  new Card(CardType.MELEE, 2, 'dandelion.jpeg'),
+  new Card(CardType.MELEE, 10, 'zoltan-chiva.png'),
+  new Card(CardType.MELEE, 9, 'ciri.jpeg'),
+  new Card(CardType.MELEE, 6, 'roche.png'),
+  new Card(CardType.MELEE, 10, 'emgir-var-emreis.jpeg'),
+  new Card(CardType.RANGE, 7, 'gyunter.jpeg'),
+  new Card(CardType.RANGE, 5, 'iorvet.jpeg'),
+  new Card(CardType.MELEE, 3, 'kerak.jpeg'),
+  new Card(CardType.MELEE, 6, 'lamberd.jpeg'),
+  new Card(CardType.MELEE, 4, 'leo-bonart.jpeg'),
+  new Card(CardType.MELEE, 9, 'vesemir.jpeg'),
+  new Card(CardType.MELEE, 7, 'yapen-zigrin.jpeg'),
+];
 
 export const MAX_CARDS_IN_HAND = 10;
 

--- a/vue/src/engine/game-engine.js
+++ b/vue/src/engine/game-engine.js
@@ -41,8 +41,8 @@ class GameEngine {
   }
 
   endPlayerTurn(passed) {
-    this.player.board.firstLineCards.map(card => card.new = false)
-    this.player.board.secondLineCards.map(card => card.new = false)
+    this.player.board.firstLineCards.map(card => card.setNew(false))
+    this.player.board.secondLineCards.map(card => card.setNew(false))
 
     if (this.opponent.passed) {
       if (passed) {
@@ -108,7 +108,7 @@ class GameEngine {
       return;
     }
 
-    const bestCardIndex = cards.reduce((bestCardIndex, card, i) => card.score > cards[bestCardIndex].score ? i : bestCardIndex, 0);
+    const bestCardIndex = cards.reduce((bestCardIndex, card, i) => card.getScore() > cards[bestCardIndex].getScore() ? i : bestCardIndex, 0);
     this.opponent.playCard(bestCardIndex);
     this.opponentTurnsQuantity++;
     this.endOpponentTurn(this.opponentTurnsQuantity >= OPPONENT_TURNS_PER_ROUND);

--- a/vue/src/engine/game-engine.js
+++ b/vue/src/engine/game-engine.js
@@ -71,8 +71,7 @@ class GameEngine {
       return;
     }
 
-    this.cardPlayed = true;
-    this.player.playCard(cardIndex, position);
+    this.cardPlayed = this.player.tryPlayCard(cardIndex, position);
   }
 
   endOpponentTurn(passed) {
@@ -102,16 +101,20 @@ class GameEngine {
 
     await sleep(Math.floor(Math.random() * MAX_OPPONENT_WAIT_MS));
 
-    const cards = this.opponent.cards;
+    const cards = [...this.opponent.cards];
 
-    if (!cards.length) {
-      return;
+    while (cards.length > 0) {
+      const bestCardIndex = cards.reduce((bestCardIndex, card, i) => card.getScore() > cards[bestCardIndex].getScore() ? i : bestCardIndex, 0);
+      const isTurnSuccess = this.opponent.tryPlayCard(bestCardIndex);
+
+      if (isTurnSuccess) {
+        this.opponentTurnsQuantity++;
+        this.endOpponentTurn(this.opponentTurnsQuantity >= OPPONENT_TURNS_PER_ROUND);
+        break;
+      }
+
+      cards.splice(bestCardIndex, 1);
     }
-
-    const bestCardIndex = cards.reduce((bestCardIndex, card, i) => card.getScore() > cards[bestCardIndex].getScore() ? i : bestCardIndex, 0);
-    this.opponent.playCard(bestCardIndex);
-    this.opponentTurnsQuantity++;
-    this.endOpponentTurn(this.opponentTurnsQuantity >= OPPONENT_TURNS_PER_ROUND);
   }
 
   endRound() {

--- a/vue/src/engine/player.js
+++ b/vue/src/engine/player.js
@@ -31,7 +31,7 @@ export class Player {
   playCard(cardIndex, position) {
     const card = this.cards[cardIndex];
     this.cards.splice(cardIndex, 1);
-    card.new = true;
+    card.setNew(true);
     return this.board.addCard(card, position);
   }
 
@@ -53,7 +53,7 @@ export class Player {
 
   removeCardFromBoard(index, type) {
     const card = this.board.getCard(index, type);
-    if (!card.new) {
+    if (!card.getNew()) {
       return;
     }
 


### PR DESCRIPTION
В рамках настоящей работы, добавлена возможность создавать специальные возможности для карт с помощью паттерна "Стратегия". В качестве примера, реализована способность для карты "Цири". Карту нельзя будет разыграть если на поле соперника есть "Геральт".

https://github.com/user-attachments/assets/b2f24cc0-4c1e-4693-a888-90bcd74c8884

P. S. Будет rebase после [этого PR'a](https://github.com/reznikovkg/vue-2-docker-compose/pull/65).

[Покатаев](https://t.me/niapoll)